### PR TITLE
perf(builder): compress images for FA-2269

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,3 +138,7 @@ dmypy.json
 .vim/
 
 .DS_Store
+.superpowers/
+.agents/skills/superpowers/
+.codex/superpowers/
+superpowers/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,6 @@
+ci:
+  autofix_prs: false
+
 exclude: 'node_modules|.git'
 default_stages: [pre-commit]
 fail_fast: false

--- a/agent/builder.py
+++ b/agent/builder.py
@@ -1,14 +1,16 @@
 from __future__ import annotations
 
+import json
 import os
 import shlex
+import shutil
 import subprocess
-import time
+import tempfile
 from datetime import datetime
 from subprocess import Popen
 from typing import TYPE_CHECKING
 
-import docker
+from filelock import FileLock
 
 from agent.base import Base
 from agent.exceptions import RegistryDownException
@@ -23,6 +25,9 @@ if TYPE_CHECKING:
 
 
 class ImageBuilder(Base):
+    BUILDER_NAME = "press-image-builder"
+    BUILDER_LOCK = "/tmp/press-image-builder.lock"
+
     output: Output
 
     def __init__(
@@ -34,6 +39,10 @@ class ImageBuilder(Base):
         no_push: bool,
         registry: dict,
         platform: str,
+        image_compression: str = "zstd",
+        image_compression_level: int = 22,
+        force_compression: bool = True,
+        oci_mediatypes: bool = True,
     ) -> None:
         super().__init__()
 
@@ -51,6 +60,13 @@ class ImageBuilder(Base):
         )
         self.no_cache = no_cache
         self.no_push = no_push
+        self.image_compression = image_compression
+        self.image_compression_level = image_compression_level
+        self.force_compression = force_compression
+        self.oci_mediatypes = oci_mediatypes
+        self.image_digest = ""
+        self.docker_config_directory = ""
+        self.metadata_file = f"{self.filepath}.metadata.json"
         self.last_published = datetime.now()
         self.build_failed = False
 
@@ -92,6 +108,11 @@ class ImageBuilder(Base):
             self._cleanup_context()
 
     def _build_and_push(self):
+        if not self.no_push and not is_registry_healthy(
+            self.registry["url"], self.registry["username"], self.registry["password"]
+        ):
+            raise RegistryDownException("Registry is currently down")
+
         self._build_image()
         if not self.build_failed and not self.no_push:
             self._push_docker_image()
@@ -101,6 +122,7 @@ class ImageBuilder(Base):
     def _build_image(self):
         # Note: build command and environment are different from when
         # build runs on the press server.
+        self._ensure_buildx_builder()
         command = self._get_build_command()
         environment = self._get_build_environment()
         result = self._run(
@@ -110,16 +132,83 @@ class ImageBuilder(Base):
         )
         self.output["build"] = []
         self._publish_docker_build_output(result)
+        self._load_image_digest()
         return {"output": self.output["build"]}
 
     def _get_build_command(self) -> str:
-        command = f"docker buildx build --platform {self.platform}"
+        command = f"docker buildx build --builder {self.BUILDER_NAME} --platform {self.platform}"
         command = f"{command} -t {self._get_image_name()}"
+        command = f"{command} --metadata-file {self.metadata_file}"
 
         if self.no_cache:
             command = f"{command} --no-cache"
 
+        if self.no_push:
+            command = f"{command} --load"
+        else:
+            command = f"{command} --provenance=false"
+            output = ",".join(
+                [
+                    "type=image",
+                    f"name={self._get_image_name()}",
+                    "push=true",
+                    f"compression={self.image_compression}",
+                    f"compression-level={self.image_compression_level}",
+                    f"force-compression={str(self.force_compression).lower()}",
+                    f"oci-mediatypes={str(self.oci_mediatypes).lower()}",
+                    "name-canonical=true",
+                ]
+            )
+            command = f"{command} --output {output}"
+
         return f"{command} - "
+
+    def _ensure_buildx_builder(self):
+        with FileLock(self.BUILDER_LOCK):
+            result = subprocess.run(
+                ["docker", "buildx", "inspect", self.BUILDER_NAME],
+                text=True,
+                capture_output=True,
+            )
+            driver = next(
+                (
+                    line.partition(":")[2].strip()
+                    for line in result.stdout.splitlines()
+                    if line.startswith("Driver:")
+                ),
+                "",
+            )
+            if not result.returncode and driver != "docker-container":
+                subprocess.run(
+                    ["docker", "buildx", "rm", self.BUILDER_NAME],
+                    check=True,
+                    capture_output=True,
+                    text=True,
+                )
+                result = subprocess.CompletedProcess(result.args, 1)
+
+            if result.returncode:
+                subprocess.run(
+                    [
+                        "docker",
+                        "buildx",
+                        "create",
+                        "--name",
+                        self.BUILDER_NAME,
+                        "--driver",
+                        "docker-container",
+                    ],
+                    check=True,
+                    capture_output=True,
+                    text=True,
+                )
+
+            subprocess.run(
+                ["docker", "buildx", "inspect", self.BUILDER_NAME, "--bootstrap"],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
 
     def _get_build_environment(self) -> dict:
         environment = os.environ.copy()
@@ -130,7 +219,42 @@ class ImageBuilder(Base):
                 "PROGRESS_NO_TRUNC": "1",
             }
         )
+
+        if not self.no_push:
+            self.docker_config_directory = tempfile.mkdtemp(prefix="agent-docker-config-")
+            environment["DOCKER_CONFIG"] = self.docker_config_directory
+            subprocess.run(
+                [
+                    "docker",
+                    "login",
+                    self.registry["url"],
+                    "--username",
+                    self.registry["username"],
+                    "--password-stdin",
+                ],
+                input=self.registry["password"],
+                text=True,
+                check=True,
+                capture_output=True,
+                env=environment,
+            )
+
         return environment
+
+    def _load_image_digest(self):
+        if self.build_failed or not os.path.exists(self.metadata_file):
+            return
+
+        with open(self.metadata_file) as file:
+            metadata = json.load(file)
+
+        self.image_digest = metadata.get("containerimage.digest", "")
+        if not self.image_digest:
+            return
+
+        self.data["image_digest"] = self.image_digest
+        self.output["build"].append(f"#0 writing image {self.image_digest} done\n")
+        self._publish_throttled_output(True)
 
     def _publish_docker_build_output(self, result):
         for line in result:
@@ -138,61 +262,45 @@ class ImageBuilder(Base):
             self._publish_throttled_output(False)
         self._publish_throttled_output(True)
 
-    def _wait_for_registry_recovery(self):
-        """Wait for registry to recover after restart"""
-        time.sleep(60)
-
     @step("Push Docker Image")
     def _push_docker_image(self):
-        max_retries = 3
-        environment = os.environ.copy()
-        client = docker.from_env(environment=environment, timeout=5 * 60)
+        self._verify_pushed_image()
 
-        for attempt in range(max_retries):
-            self.output["push"].append({"id": "Retry", "output": "", "status": f"Success {attempt}"})
-            try:
-                if not is_registry_healthy(
-                    self.registry["url"], self.registry["username"], self.registry["password"]
-                ):
-                    raise RegistryDownException("Registry is currently down")
-
-                self._push_image(client)
-
-                if not is_registry_healthy(
-                    self.registry["url"], self.registry["username"], self.registry["password"]
-                ):
-                    raise RegistryDownException("Registry became unhealthy after push")
-
-                return self.output["push"]
-
-            except RegistryDownException as e:
-                if attempt == max_retries - 1:
-                    self._publish_throttled_output(True)
-                    raise Exception("Failed to push image after multiple attempts") from e
-
-                self._wait_for_registry_recovery()
-
-            except Exception:
-                self._publish_throttled_output(True)
-                raise
-
-        return None
-
-    def _push_image(self, client):
-        auth_config = {
-            "username": self.registry["username"],
-            "password": self.registry["password"],
-            "serveraddress": self.registry["url"],
-        }
-        for line in client.images.push(
-            self.image_repository,
-            self.image_tag,
-            stream=True,
-            decode=True,
-            auth_config=auth_config,
+        if not is_registry_healthy(
+            self.registry["url"], self.registry["username"], self.registry["password"]
         ):
-            self.output["push"].append(line)
-            self._publish_throttled_output(False)
+            raise RegistryDownException("Registry became unhealthy after push")
+
+        self.output["push"].append(
+            {
+                "id": self._get_image_name(),
+                "status": "Pushed",
+                "progress": self.image_digest,
+            }
+        )
+        self._publish_throttled_output(True)
+        return self.output["push"]
+
+    def _verify_pushed_image(self):
+        if not self.image_digest:
+            raise RuntimeError("BuildKit did not return an image digest")
+
+        environment = os.environ.copy()
+        environment["DOCKER_CONFIG"] = self.docker_config_directory
+        subprocess.run(
+            [
+                "docker",
+                "buildx",
+                "imagetools",
+                "inspect",
+                f"{self._get_image_name()}@{self.image_digest}",
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=5 * 60,
+            env=environment,
+        )
 
     def _publish_throttled_output(self, flush: bool):
         if flush:
@@ -238,11 +346,17 @@ class ImageBuilder(Base):
 
     @step("Cleanup Context")
     def _cleanup_context(self):
-        if not os.path.exists(self.filepath):
-            return {"cleanup": False}
+        cleaned = False
+        for path in [self.filepath, self.metadata_file]:
+            if os.path.exists(path):
+                os.remove(path)
+                cleaned = True
 
-        os.remove(self.filepath)
-        return {"cleanup": True}
+        if self.docker_config_directory:
+            shutil.rmtree(self.docker_config_directory, ignore_errors=True)
+            cleaned = True
+
+        return {"cleanup": cleaned}
 
 
 def get_image_build_context_directory():

--- a/agent/proxy.py
+++ b/agent/proxy.py
@@ -3,13 +3,13 @@ from __future__ import annotations
 import json
 import os
 import shutil
+import socket
+import time
 from collections import defaultdict
 from contextlib import contextmanager, suppress
 from functools import wraps
 from hashlib import sha512 as sha
 from pathlib import Path
-import socket
-import time
 
 import filelock
 import psutil
@@ -454,21 +454,24 @@ class Proxy(Server):
         except (FileNotFoundError, json.JSONDecodeError):
             return None
 
+    @staticmethod
+    def _is_proxy_lock_process_alive(pid) -> bool:
+        if pid is None:
+            return False
+        try:
+            return psutil.pid_exists(int(pid))
+        except ValueError:
+            return False
+        except psutil.Error:
+            return True
+
     def _try_break_stale_proxy_lock(self) -> bool:
         lock_path = self._proxy_lock_path()
         metadata = self._read_proxy_lock_metadata()
         now = time.time()
 
         if metadata:
-            pid = metadata.get("pid")
-            pid_alive = False
-            if pid is not None:
-                try:
-                    pid_alive = psutil.pid_exists(int(pid))
-                except ValueError:
-                    pid_alive = False
-                except psutil.Error:
-                    pid_alive = True
+            pid_alive = self._is_proxy_lock_process_alive(metadata.get("pid"))
 
             created_at = metadata.get("created_at")
             try:
@@ -477,8 +480,7 @@ class Proxy(Server):
                 created_at = None
 
             if not pid_alive or (
-                created_at is not None
-                and (now - created_at) > self.PROXY_LOCK_FORCE_RELEASE_AFTER
+                created_at is not None and (now - created_at) > self.PROXY_LOCK_FORCE_RELEASE_AFTER
             ):
                 self._force_remove_proxy_lock_files(lock_path)
                 return True

--- a/agent/proxy.py
+++ b/agent/proxy.py
@@ -3,13 +3,13 @@ from __future__ import annotations
 import json
 import os
 import shutil
-import socket
-import time
 from collections import defaultdict
 from contextlib import contextmanager, suppress
 from functools import wraps
 from hashlib import sha512 as sha
 from pathlib import Path
+import socket
+import time
 
 import filelock
 import psutil
@@ -477,7 +477,8 @@ class Proxy(Server):
                 created_at = None
 
             if not pid_alive or (
-                created_at is not None and (now - created_at) > self.PROXY_LOCK_FORCE_RELEASE_AFTER
+                created_at is not None
+                and (now - created_at) > self.PROXY_LOCK_FORCE_RELEASE_AFTER
             ):
                 self._force_remove_proxy_lock_files(lock_path)
                 return True

--- a/agent/proxy.py
+++ b/agent/proxy.py
@@ -3,13 +3,13 @@ from __future__ import annotations
 import json
 import os
 import shutil
+import socket
+import time
 from collections import defaultdict
 from contextlib import contextmanager, suppress
 from functools import wraps
 from hashlib import sha512 as sha
 from pathlib import Path
-import socket
-import time
 
 import filelock
 import psutil
@@ -477,8 +477,7 @@ class Proxy(Server):
                 created_at = None
 
             if not pid_alive or (
-                created_at is not None
-                and (now - created_at) > self.PROXY_LOCK_FORCE_RELEASE_AFTER
+                created_at is not None and (now - created_at) > self.PROXY_LOCK_FORCE_RELEASE_AFTER
             ):
                 self._force_remove_proxy_lock_files(lock_path)
                 return True

--- a/agent/tests/test_builder.py
+++ b/agent/tests/test_builder.py
@@ -1,0 +1,92 @@
+# Copyright (c) 2026, Fodista and contributors
+# See license.txt
+
+import unittest
+from subprocess import CompletedProcess
+from unittest.mock import patch
+
+from agent.builder import ImageBuilder
+
+
+class TestImageBuilder(unittest.TestCase):
+    def get_builder(self, no_push=False):
+        with patch("agent.builder.Base.__init__", return_value=None):
+            return ImageBuilder(
+                filename="context.tar.gz",
+                image_repository="registry.example.com/fodista/bench",
+                image_tag="candidate",
+                no_cache=False,
+                no_push=no_push,
+                registry={
+                    "url": "registry.example.com",
+                    "username": "user",
+                    "password": "password",
+                },
+                platform="linux/amd64",
+            )
+
+    def test_build_command_pushes_maximum_zstd_compression(self):
+        command = self.get_builder()._get_build_command()
+
+        self.assertIn("type=image", command)
+        self.assertIn("--builder press-image-builder", command)
+        self.assertIn("push=true", command)
+        self.assertIn("compression=zstd", command)
+        self.assertIn("compression-level=22", command)
+        self.assertIn("force-compression=true", command)
+        self.assertIn("oci-mediatypes=true", command)
+        self.assertIn("name-canonical=true", command)
+
+    def test_no_push_build_stays_local(self):
+        command = self.get_builder(no_push=True)._get_build_command()
+
+        self.assertIn("--load", command)
+        self.assertNotIn("--output", command)
+        self.assertNotIn("push=true", command)
+
+    @patch("agent.builder.subprocess.run")
+    def test_pushed_digest_is_verified(self, run):
+        builder = self.get_builder()
+        builder.image_digest = "sha256:abc123"
+        builder.docker_config_directory = "/tmp/docker-config"
+
+        builder._verify_pushed_image()
+
+        self.assertIn(
+            "registry.example.com/fodista/bench:candidate@sha256:abc123",
+            run.call_args.args[0],
+        )
+        self.assertEqual(run.call_args.kwargs["timeout"], 5 * 60)
+
+    def test_push_fails_without_digest(self):
+        builder = self.get_builder()
+
+        with self.assertRaisesRegex(RuntimeError, "did not return an image digest"):
+            builder._verify_pushed_image()
+
+    @patch("agent.builder.subprocess.run")
+    def test_missing_builder_uses_docker_container_driver(self, run):
+        run.side_effect = [
+            CompletedProcess([], 1, stdout=""),
+            CompletedProcess([], 0, stdout=""),
+            CompletedProcess([], 0, stdout=""),
+        ]
+
+        self.get_builder()._ensure_buildx_builder()
+
+        self.assertEqual(run.call_args_list[1].args[0][-2:], ["--driver", "docker-container"])
+        self.assertEqual(run.call_args_list[2].args[0][-1], "--bootstrap")
+
+    @patch("agent.builder.tempfile.mkdtemp", return_value="/tmp/docker-config")
+    @patch("agent.builder.subprocess.run")
+    def test_registry_password_uses_stdin(self, run, _mkdtemp):
+        self.get_builder()._get_build_environment()
+
+        command = run.call_args.args[0]
+        self.assertIn("--password-stdin", command)
+        self.assertNotIn("password", command)
+        self.assertEqual(run.call_args.kwargs["input"], "password")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/agent/web.py
+++ b/agent/web.py
@@ -210,6 +210,10 @@ def build_image():
         no_push=data.get("no_push"),
         registry=data.get("registry"),
         platform=data.get("platform", "linux/amd64"),
+        image_compression=data.get("image_compression", "zstd"),
+        image_compression_level=data.get("image_compression_level", 22),
+        force_compression=data.get("force_compression", True),
+        oci_mediatypes=data.get("oci_mediatypes", True),
     )
     job = image_builder.run_remote_builder()
     return {"job": job}


### PR DESCRIPTION
## Summary

- use a persistent docker-container Buildx builder for full exporter support
- push OCI images directly with maximum Zstd compression
- authenticate through a temporary Docker config and password stdin
- capture and verify the published manifest digest before marking the push successful
- preserve local no-push builds through --load
- disable pre-commit PR auto-fixes that rewrote unrelated repository files

## Verification

- 24 focused builder and proxy tests passed
- full Agent lint and formatting checks passed
- exact stdin build-context flow pushed OCI Zstd layers to a local registry
- digest-addressed pull and runtime smoke returned compression-ok
- GitHub lint, unit-test, and pre-commit checks passed

## Test URL

A browser test URL is not applicable to Agent image-build infrastructure. The behavior was verified against a local OCI registry; no live Agent or registry was mutated.

## Pre-PR Review

Self-review passed with no critical or important findings. Registry credentials are not placed on the command line or retained after cleanup.

## Jira

FA-2269