### PR TITLE
fix(builder): preserve buildx config for FA-2269

### DIFF
--- a/agent/builder.py
+++ b/agent/builder.py
@@ -212,6 +212,10 @@ class ImageBuilder(Base):
 
     def _get_build_environment(self) -> dict:
         environment = os.environ.copy()
+        environment["BUILDX_CONFIG"] = environment.get(
+            "BUILDX_CONFIG",
+            os.path.join(environment.get("DOCKER_CONFIG", os.path.expanduser("~/.docker")), "buildx"),
+        )
         environment.update(
             {
                 "DOCKER_BUILDKIT": "1",

--- a/agent/tests/test_builder.py
+++ b/agent/tests/test_builder.py
@@ -80,12 +80,15 @@ class TestImageBuilder(unittest.TestCase):
     @patch("agent.builder.tempfile.mkdtemp", return_value="/tmp/docker-config")
     @patch("agent.builder.subprocess.run")
     def test_registry_password_uses_stdin(self, run, _mkdtemp):
-        self.get_builder()._get_build_environment()
+        with patch.dict("agent.builder.os.environ", {"DOCKER_CONFIG": "/persistent/docker"}, clear=True):
+            environment = self.get_builder()._get_build_environment()
 
         command = run.call_args.args[0]
         self.assertIn("--password-stdin", command)
         self.assertNotIn("password", command)
         self.assertEqual(run.call_args.kwargs["input"], "password")
+        self.assertEqual(environment["DOCKER_CONFIG"], "/tmp/docker-config")
+        self.assertEqual(environment["BUILDX_CONFIG"], "/persistent/docker/buildx")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- keep Buildx builder metadata in the persistent builder store when registry credentials use a temporary Docker config
- add regression coverage for separate `DOCKER_CONFIG` and `BUILDX_CONFIG` paths

Jira: FA-2269

## Verification

- `python -m unittest agent.tests.test_builder agent.tests.test_proxy` — 24 passed
- `ruff check agent` — passed
- `ruff format --check agent/builder.py agent/tests/test_builder.py` — passed
- direct Docker reproduction: temporary `DOCKER_CONFIG` produced `no builder found`; adding the persistent `BUILDX_CONFIG` found the same docker-container builder

## Functional test URL

Not available: this Agent builder path has no browser surface and requires an authenticated Press build job, uploaded Docker context, and private registry credentials. Direct Docker/Buildx reproduction provides the functional proof.

## Pre-PR Review

No blocking findings. The change preserves temporary registry credentials, the persistent builder cache, and the existing build lock.