### PR TITLE
feat(builder): publish runtime image target FA-2363

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,6 +139,7 @@ dmypy.json
 
 .DS_Store
 .superpowers/
+docs/superpowers/
 .agents/skills/superpowers/
 .codex/superpowers/
 superpowers/

--- a/agent/builder.py
+++ b/agent/builder.py
@@ -1,14 +1,17 @@
 from __future__ import annotations
 
+import json
 import os
 import shlex
+import shutil
 import subprocess
+import tempfile
 import time
 from datetime import datetime
 from subprocess import Popen
 from typing import TYPE_CHECKING
 
-import docker
+from filelock import FileLock
 
 from agent.base import Base
 from agent.exceptions import RegistryDownException
@@ -23,6 +26,21 @@ if TYPE_CHECKING:
 
 
 class ImageBuilder(Base):
+    BUILDER_NAME = "press-image-builder"
+    BUILDER_LOCK = "/tmp/press-image-builder.lock"
+    MAX_BUILD_ATTEMPTS = 3
+    REGISTRY_RETRY_DELAY = 60
+    REGISTRY_ERROR_MARKERS = (
+        "connection refused",
+        "connection reset by peer",
+        "context deadline exceeded",
+        "failed to do request",
+        "failed to push",
+        "i/o timeout",
+        "tls handshake timeout",
+        "unexpected status from",
+    )
+
     output: Output
 
     def __init__(
@@ -34,6 +52,10 @@ class ImageBuilder(Base):
         no_push: bool,
         registry: dict,
         platform: str,
+        image_compression: str = "gzip",
+        image_compression_level: int = 0,
+        force_compression: bool = False,
+        oci_mediatypes: bool = False,
     ) -> None:
         super().__init__()
 
@@ -51,6 +73,13 @@ class ImageBuilder(Base):
         )
         self.no_cache = no_cache
         self.no_push = no_push
+        self.image_compression = image_compression
+        self.image_compression_level = image_compression_level
+        self.force_compression = force_compression
+        self.oci_mediatypes = oci_mediatypes
+        self.image_digest = ""
+        self.docker_config_directory = ""
+        self.metadata_file = f"{self.filepath}.metadata.json"
         self.last_published = datetime.now()
         self.build_failed = False
 
@@ -93,6 +122,9 @@ class ImageBuilder(Base):
 
     def _build_and_push(self):
         self._build_image()
+        if self.build_failed:
+            raise RuntimeError("Docker image build or registry push failed")
+
         if not self.build_failed and not self.no_push:
             self._push_docker_image()
         return self.data
@@ -101,28 +133,122 @@ class ImageBuilder(Base):
     def _build_image(self):
         # Note: build command and environment are different from when
         # build runs on the press server.
-        command = self._get_build_command()
         environment = self._get_build_environment()
-        result = self._run(
-            command=command,
-            environment=environment,
-            input_filepath=self.filepath,
-        )
-        self.output["build"] = []
-        self._publish_docker_build_output(result)
+        self._ensure_buildx_builder(environment)
+        command = self._get_build_command()
+
+        for attempt in range(self.MAX_BUILD_ATTEMPTS):
+            result = self._run(
+                command=command,
+                environment=environment,
+                input_filepath=self.filepath,
+            )
+            self.output["build"] = []
+            self._publish_docker_build_output(result)
+            if not self.build_failed:
+                self._load_image_digest()
+                break
+
+            if (
+                self.no_push
+                or attempt == self.MAX_BUILD_ATTEMPTS - 1
+                or not self._is_retryable_registry_failure()
+            ):
+                raise RuntimeError("Docker image build or registry push failed")
+
+            time.sleep(self.REGISTRY_RETRY_DELAY)
+
         return {"output": self.output["build"]}
 
+    def _is_retryable_registry_failure(self):
+        output = "".join(self.output["build"]).lower()
+        return any(marker in output for marker in self.REGISTRY_ERROR_MARKERS)
+
     def _get_build_command(self) -> str:
-        command = f"docker buildx build --platform {self.platform}"
+        command = f"docker buildx build --builder {self.BUILDER_NAME} --platform {self.platform}"
         command = f"{command} -t {self._get_image_name()}"
+        command = f"{command} --metadata-file {self.metadata_file}"
 
         if self.no_cache:
             command = f"{command} --no-cache"
 
+        if self.no_push:
+            command = f"{command} --load"
+        else:
+            command = f"{command} --provenance=false"
+            output = ",".join(
+                [
+                    "type=image",
+                    f"name={self._get_image_name()}",
+                    "push=true",
+                    f"compression={self.image_compression}",
+                    f"compression-level={self.image_compression_level}",
+                    f"force-compression={str(self.force_compression).lower()}",
+                    f"oci-mediatypes={str(self.oci_mediatypes).lower()}",
+                    "name-canonical=true",
+                ]
+            )
+            command = f"{command} --output {output}"
+
         return f"{command} - "
+
+    def _ensure_buildx_builder(self, environment: dict):
+        with FileLock(self.BUILDER_LOCK):
+            result = subprocess.run(
+                ["docker", "buildx", "inspect", self.BUILDER_NAME],
+                text=True,
+                capture_output=True,
+                env=environment,
+            )
+            driver = next(
+                (
+                    line.partition(":")[2].strip()
+                    for line in result.stdout.splitlines()
+                    if line.startswith("Driver:")
+                ),
+                "",
+            )
+            if not result.returncode and driver != "docker-container":
+                subprocess.run(
+                    ["docker", "buildx", "rm", self.BUILDER_NAME],
+                    check=True,
+                    capture_output=True,
+                    text=True,
+                    env=environment,
+                )
+                result = subprocess.CompletedProcess(result.args, 1)
+
+            if result.returncode:
+                subprocess.run(
+                    [
+                        "docker",
+                        "buildx",
+                        "create",
+                        "--name",
+                        self.BUILDER_NAME,
+                        "--driver",
+                        "docker-container",
+                    ],
+                    check=True,
+                    capture_output=True,
+                    text=True,
+                    env=environment,
+                )
+
+            subprocess.run(
+                ["docker", "buildx", "inspect", self.BUILDER_NAME, "--bootstrap"],
+                check=True,
+                capture_output=True,
+                text=True,
+                env=environment,
+            )
 
     def _get_build_environment(self) -> dict:
         environment = os.environ.copy()
+        environment["BUILDX_CONFIG"] = environment.get(
+            "BUILDX_CONFIG",
+            os.path.join(environment.get("DOCKER_CONFIG", os.path.expanduser("~/.docker")), "buildx"),
+        )
         environment.update(
             {
                 "DOCKER_BUILDKIT": "1",
@@ -130,7 +256,56 @@ class ImageBuilder(Base):
                 "PROGRESS_NO_TRUNC": "1",
             }
         )
+
+        if not self.no_push:
+            if not self.docker_config_directory:
+                self.docker_config_directory = tempfile.mkdtemp(prefix="agent-docker-config-")
+                self._login_to_registry(environment)
+
+            environment["DOCKER_CONFIG"] = self.docker_config_directory
+
         return environment
+
+    def _login_to_registry(self, environment):
+        command = [
+            "docker",
+            "login",
+            self.registry["url"],
+            "--username",
+            self.registry["username"],
+            "--password-stdin",
+        ]
+        environment = {**environment, "DOCKER_CONFIG": self.docker_config_directory}
+        for attempt in range(self.MAX_BUILD_ATTEMPTS):
+            try:
+                subprocess.run(
+                    command,
+                    input=self.registry["password"],
+                    text=True,
+                    check=True,
+                    capture_output=True,
+                    env=environment,
+                )
+                return
+            except subprocess.CalledProcessError:
+                if attempt == self.MAX_BUILD_ATTEMPTS - 1:
+                    raise
+                time.sleep(self.REGISTRY_RETRY_DELAY)
+
+    def _load_image_digest(self):
+        if self.build_failed or not os.path.exists(self.metadata_file):
+            return
+
+        with open(self.metadata_file) as file:
+            metadata = json.load(file)
+
+        self.image_digest = metadata.get("containerimage.digest", "")
+        if not self.image_digest:
+            return
+
+        self.data["image_digest"] = self.image_digest
+        self.output["build"].append(f"#0 writing image {self.image_digest} done\n")
+        self._publish_throttled_output(True)
 
     def _publish_docker_build_output(self, result):
         for line in result:
@@ -138,61 +313,45 @@ class ImageBuilder(Base):
             self._publish_throttled_output(False)
         self._publish_throttled_output(True)
 
-    def _wait_for_registry_recovery(self):
-        """Wait for registry to recover after restart"""
-        time.sleep(60)
-
     @step("Push Docker Image")
     def _push_docker_image(self):
-        max_retries = 3
-        environment = os.environ.copy()
-        client = docker.from_env(environment=environment, timeout=5 * 60)
+        self._verify_pushed_image()
 
-        for attempt in range(max_retries):
-            self.output["push"].append({"id": "Retry", "output": "", "status": f"Success {attempt}"})
-            try:
-                if not is_registry_healthy(
-                    self.registry["url"], self.registry["username"], self.registry["password"]
-                ):
-                    raise RegistryDownException("Registry is currently down")
-
-                self._push_image(client)
-
-                if not is_registry_healthy(
-                    self.registry["url"], self.registry["username"], self.registry["password"]
-                ):
-                    raise RegistryDownException("Registry became unhealthy after push")
-
-                return self.output["push"]
-
-            except RegistryDownException as e:
-                if attempt == max_retries - 1:
-                    self._publish_throttled_output(True)
-                    raise Exception("Failed to push image after multiple attempts") from e
-
-                self._wait_for_registry_recovery()
-
-            except Exception:
-                self._publish_throttled_output(True)
-                raise
-
-        return None
-
-    def _push_image(self, client):
-        auth_config = {
-            "username": self.registry["username"],
-            "password": self.registry["password"],
-            "serveraddress": self.registry["url"],
-        }
-        for line in client.images.push(
-            self.image_repository,
-            self.image_tag,
-            stream=True,
-            decode=True,
-            auth_config=auth_config,
+        if not is_registry_healthy(
+            self.registry["url"], self.registry["username"], self.registry["password"]
         ):
-            self.output["push"].append(line)
-            self._publish_throttled_output(False)
+            raise RegistryDownException("Registry became unhealthy after push")
+
+        self.output["push"].append(
+            {
+                "id": self._get_image_name(),
+                "status": "Pushed",
+                "progress": self.image_digest,
+            }
+        )
+        self._publish_throttled_output(True)
+        return self.output["push"]
+
+    def _verify_pushed_image(self):
+        if not self.image_digest:
+            raise RuntimeError("BuildKit did not return an image digest")
+
+        environment = os.environ.copy()
+        environment["DOCKER_CONFIG"] = self.docker_config_directory
+        subprocess.run(
+            [
+                "docker",
+                "buildx",
+                "imagetools",
+                "inspect",
+                f"{self._get_image_name()}@{self.image_digest}",
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=5 * 60,
+            env=environment,
+        )
 
     def _publish_throttled_output(self, flush: bool):
         if flush:
@@ -238,11 +397,17 @@ class ImageBuilder(Base):
 
     @step("Cleanup Context")
     def _cleanup_context(self):
-        if not os.path.exists(self.filepath):
-            return {"cleanup": False}
+        cleaned = False
+        for path in [self.filepath, self.metadata_file]:
+            if os.path.exists(path):
+                os.remove(path)
+                cleaned = True
 
-        os.remove(self.filepath)
-        return {"cleanup": True}
+        if self.docker_config_directory:
+            shutil.rmtree(self.docker_config_directory, ignore_errors=True)
+            cleaned = True
+
+        return {"cleanup": cleaned}
 
 
 def get_image_build_context_directory():

--- a/agent/builder.py
+++ b/agent/builder.py
@@ -56,6 +56,7 @@ class ImageBuilder(Base):
         image_compression_level: int = 0,
         force_compression: bool = False,
         oci_mediatypes: bool = False,
+        build_runtime_image: bool = False,
     ) -> None:
         super().__init__()
 
@@ -77,9 +78,12 @@ class ImageBuilder(Base):
         self.image_compression_level = image_compression_level
         self.force_compression = force_compression
         self.oci_mediatypes = oci_mediatypes
+        self.build_runtime_image = build_runtime_image
         self.image_digest = ""
+        self.runtime_image_digest = ""
         self.docker_config_directory = ""
         self.metadata_file = f"{self.filepath}.metadata.json"
+        self.runtime_metadata_file = f"{self.filepath}.runtime.metadata.json"
         self.last_published = datetime.now()
         self.build_failed = False
 
@@ -125,17 +129,23 @@ class ImageBuilder(Base):
         if self.build_failed:
             raise RuntimeError("Docker image build or registry push failed")
 
+        if self.build_runtime_image and not self.no_push:
+            self._build_image(runtime=True)
+            if self.build_failed:
+                raise RuntimeError("Docker image build or registry push failed")
+
         if not self.build_failed and not self.no_push:
             self._push_docker_image()
         return self.data
 
     @step("Build Image")
-    def _build_image(self):
+    def _build_image(self, runtime: bool = False):
         # Note: build command and environment are different from when
         # build runs on the press server.
         environment = self._get_build_environment()
         self._ensure_buildx_builder(environment)
-        command = self._get_build_command()
+        command = self._get_build_command(runtime)
+        variant_output_start = len(self.output["build"])
 
         for attempt in range(self.MAX_BUILD_ATTEMPTS):
             result = self._run(
@@ -143,16 +153,16 @@ class ImageBuilder(Base):
                 environment=environment,
                 input_filepath=self.filepath,
             )
-            self.output["build"] = []
+            del self.output["build"][variant_output_start:]
             self._publish_docker_build_output(result)
             if not self.build_failed:
-                self._load_image_digest()
+                self._load_image_digest(runtime)
                 break
 
             if (
                 self.no_push
                 or attempt == self.MAX_BUILD_ATTEMPTS - 1
-                or not self._is_retryable_registry_failure()
+                or not self._is_retryable_registry_failure(variant_output_start)
             ):
                 raise RuntimeError("Docker image build or registry push failed")
 
@@ -160,14 +170,19 @@ class ImageBuilder(Base):
 
         return {"output": self.output["build"]}
 
-    def _is_retryable_registry_failure(self):
-        output = "".join(self.output["build"]).lower()
+    def _is_retryable_registry_failure(self, output_start: int = 0):
+        output = "".join(self.output["build"][output_start:]).lower()
         return any(marker in output for marker in self.REGISTRY_ERROR_MARKERS)
 
-    def _get_build_command(self) -> str:
+    def _get_build_command(self, runtime: bool = False) -> str:
         command = f"docker buildx build --builder {self.BUILDER_NAME} --platform {self.platform}"
-        command = f"{command} -t {self._get_image_name()}"
-        command = f"{command} --metadata-file {self.metadata_file}"
+        image_name = self._get_image_name(runtime)
+        metadata_file = self.runtime_metadata_file if runtime else self.metadata_file
+        command = f"{command} -t {image_name}"
+        command = f"{command} --metadata-file {metadata_file}"
+
+        if runtime:
+            command = f"{command} --target runtime"
 
         if self.no_cache:
             command = f"{command} --no-cache"
@@ -179,7 +194,7 @@ class ImageBuilder(Base):
             output = ",".join(
                 [
                     "type=image",
-                    f"name={self._get_image_name()}",
+                    f"name={image_name}",
                     "push=true",
                     f"compression={self.image_compression}",
                     f"compression-level={self.image_compression_level}",
@@ -292,19 +307,25 @@ class ImageBuilder(Base):
                     raise
                 time.sleep(self.REGISTRY_RETRY_DELAY)
 
-    def _load_image_digest(self):
-        if self.build_failed or not os.path.exists(self.metadata_file):
+    def _load_image_digest(self, runtime: bool = False):
+        metadata_file = self.runtime_metadata_file if runtime else self.metadata_file
+        if self.build_failed or not os.path.exists(metadata_file):
             return
 
-        with open(self.metadata_file) as file:
+        with open(metadata_file) as file:
             metadata = json.load(file)
 
-        self.image_digest = metadata.get("containerimage.digest", "")
-        if not self.image_digest:
+        image_digest = metadata.get("containerimage.digest", "")
+        if not image_digest:
             return
 
-        self.data["image_digest"] = self.image_digest
-        self.output["build"].append(f"#0 writing image {self.image_digest} done\n")
+        if runtime:
+            self.runtime_image_digest = image_digest
+            self.data["runtime_image_digest"] = image_digest
+        else:
+            self.image_digest = image_digest
+            self.data["image_digest"] = image_digest
+        self.output["build"].append(f"#0 writing image {image_digest} done\n")
         self._publish_throttled_output(True)
 
     def _publish_docker_build_output(self, result):
@@ -316,6 +337,8 @@ class ImageBuilder(Base):
     @step("Push Docker Image")
     def _push_docker_image(self):
         self._verify_pushed_image()
+        if self.build_runtime_image:
+            self._verify_pushed_image(runtime=True)
 
         if not is_registry_healthy(
             self.registry["url"], self.registry["username"], self.registry["password"]
@@ -329,11 +352,20 @@ class ImageBuilder(Base):
                 "progress": self.image_digest,
             }
         )
+        if self.build_runtime_image:
+            self.output["push"].append(
+                {
+                    "id": self._get_image_name(runtime=True),
+                    "status": "Pushed",
+                    "progress": self.runtime_image_digest,
+                }
+            )
         self._publish_throttled_output(True)
         return self.output["push"]
 
-    def _verify_pushed_image(self):
-        if not self.image_digest:
+    def _verify_pushed_image(self, runtime: bool = False):
+        image_digest = self.runtime_image_digest if runtime else self.image_digest
+        if not image_digest:
             raise RuntimeError("BuildKit did not return an image digest")
 
         environment = os.environ.copy()
@@ -344,7 +376,7 @@ class ImageBuilder(Base):
                 "buildx",
                 "imagetools",
                 "inspect",
-                f"{self._get_image_name()}@{self.image_digest}",
+                f"{self._get_image_name(runtime)}@{image_digest}",
             ],
             check=True,
             capture_output=True,
@@ -365,8 +397,9 @@ class ImageBuilder(Base):
         self.last_published = now
         self.publish_data(self.output)
 
-    def _get_image_name(self):
-        return f"{self.image_repository}:{self.image_tag}"
+    def _get_image_name(self, runtime: bool = False):
+        image_tag = f"{self.image_tag}-runtime" if runtime else self.image_tag
+        return f"{self.image_repository}:{image_tag}"
 
     def _run(
         self,
@@ -398,7 +431,7 @@ class ImageBuilder(Base):
     @step("Cleanup Context")
     def _cleanup_context(self):
         cleaned = False
-        for path in [self.filepath, self.metadata_file]:
+        for path in [self.filepath, self.metadata_file, self.runtime_metadata_file]:
             if os.path.exists(path):
                 os.remove(path)
                 cleaned = True

--- a/agent/tests/test_builder.py
+++ b/agent/tests/test_builder.py
@@ -1,0 +1,149 @@
+# Copyright (c) 2026, Fodista and contributors
+# See license.txt
+
+import unittest
+from subprocess import CalledProcessError, CompletedProcess
+from unittest.mock import patch
+
+from agent.builder import ImageBuilder
+
+
+class TestImageBuilder(unittest.TestCase):
+    def get_builder(self, no_push=False, maximum_compression=True):
+        compression = {
+            "image_compression": "zstd",
+            "image_compression_level": 22,
+            "force_compression": True,
+            "oci_mediatypes": True,
+        }
+        with patch("agent.builder.Base.__init__", return_value=None):
+            return ImageBuilder(
+                filename="context.tar.gz",
+                image_repository="registry.example.com/fodista/bench",
+                image_tag="candidate",
+                no_cache=False,
+                no_push=no_push,
+                registry={
+                    "url": "registry.example.com",
+                    "username": "user",
+                    "password": "password",
+                },
+                platform="linux/amd64",
+                **(compression if maximum_compression else {}),
+            )
+
+    def test_build_command_pushes_maximum_zstd_compression(self):
+        command = self.get_builder()._get_build_command()
+
+        self.assertIn("type=image", command)
+        self.assertIn("--builder press-image-builder", command)
+        self.assertIn("push=true", command)
+        self.assertIn("compression=zstd", command)
+        self.assertIn("compression-level=22", command)
+        self.assertIn("force-compression=true", command)
+        self.assertIn("oci-mediatypes=true", command)
+        self.assertIn("name-canonical=true", command)
+
+    def test_default_compression_preserves_existing_clients(self):
+        command = self.get_builder(maximum_compression=False)._get_build_command()
+
+        self.assertIn("compression=gzip", command)
+        self.assertIn("compression-level=0", command)
+        self.assertIn("force-compression=false", command)
+        self.assertIn("oci-mediatypes=false", command)
+
+    def test_no_push_build_stays_local(self):
+        command = self.get_builder(no_push=True)._get_build_command()
+
+        self.assertIn("--load", command)
+        self.assertNotIn("--output", command)
+        self.assertNotIn("push=true", command)
+
+    @patch("agent.builder.subprocess.run")
+    def test_pushed_digest_is_verified(self, run):
+        builder = self.get_builder()
+        builder.image_digest = "sha256:abc123"
+        builder.docker_config_directory = "/tmp/docker-config"
+
+        builder._verify_pushed_image()
+
+        self.assertIn(
+            "registry.example.com/fodista/bench:candidate@sha256:abc123",
+            run.call_args.args[0],
+        )
+        self.assertEqual(run.call_args.kwargs["timeout"], 5 * 60)
+
+    def test_push_fails_without_digest(self):
+        builder = self.get_builder()
+
+        with self.assertRaisesRegex(RuntimeError, "did not return an image digest"):
+            builder._verify_pushed_image()
+
+    def test_registry_push_failure_is_retryable(self):
+        builder = self.get_builder()
+        builder.output["build"] = ["ERROR: failed to push: connection reset by peer\n"]
+
+        self.assertTrue(builder._is_retryable_registry_failure())
+
+    def test_dockerfile_failure_is_not_retryable(self):
+        builder = self.get_builder()
+        builder.output["build"] = ['ERROR: process "/bin/sh -c false" did not complete successfully\n']
+
+        self.assertFalse(builder._is_retryable_registry_failure())
+
+    @patch.object(ImageBuilder, "_build_image")
+    def test_failed_build_cannot_complete_successfully(self, build_image):
+        builder = self.get_builder(no_push=True)
+        build_image.side_effect = lambda: setattr(builder, "build_failed", True)
+
+        with self.assertRaisesRegex(RuntimeError, "build or registry push failed"):
+            builder._build_and_push()
+
+    @patch("agent.builder.subprocess.run")
+    def test_missing_builder_uses_docker_container_driver(self, run):
+        run.side_effect = [
+            CompletedProcess([], 1, stdout=""),
+            CompletedProcess([], 0, stdout=""),
+            CompletedProcess([], 0, stdout=""),
+        ]
+        environment = {"BUILDX_CONFIG": "/persistent/docker/buildx"}
+
+        self.get_builder()._ensure_buildx_builder(environment)
+
+        self.assertEqual(run.call_args_list[1].args[0][-2:], ["--driver", "docker-container"])
+        self.assertEqual(run.call_args_list[2].args[0][-1], "--bootstrap")
+        self.assertIs(run.call_args_list[0].kwargs["env"], environment)
+        self.assertIs(run.call_args_list[1].kwargs["env"], environment)
+        self.assertIs(run.call_args_list[2].kwargs["env"], environment)
+
+    @patch("agent.builder.tempfile.mkdtemp", return_value="/tmp/docker-config")
+    @patch("agent.builder.subprocess.run")
+    def test_registry_password_uses_stdin_and_keeps_builder_config(self, run, _mkdtemp):
+        with patch.dict("agent.builder.os.environ", {"DOCKER_CONFIG": "/persistent/docker"}, clear=True):
+            environment = self.get_builder()._get_build_environment()
+
+        command = run.call_args.args[0]
+        self.assertIn("--password-stdin", command)
+        self.assertNotIn("password", command)
+        self.assertEqual(run.call_args.kwargs["input"], "password")
+        self.assertEqual(environment["DOCKER_CONFIG"], "/tmp/docker-config")
+        self.assertEqual(environment["BUILDX_CONFIG"], "/persistent/docker/buildx")
+
+    @patch("agent.builder.time.sleep")
+    @patch("agent.builder.subprocess.run")
+    def test_registry_login_retries_transient_failure(self, run, sleep):
+        run.side_effect = [
+            CalledProcessError(1, ["docker", "login"]),
+            CompletedProcess([], 0),
+        ]
+        builder = self.get_builder()
+        builder.docker_config_directory = "/tmp/docker-config"
+
+        builder._login_to_registry({})
+
+        self.assertEqual(run.call_count, 2)
+        sleep.assert_called_once_with(builder.REGISTRY_RETRY_DELAY)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/agent/tests/test_builder.py
+++ b/agent/tests/test_builder.py
@@ -3,13 +3,13 @@
 
 import unittest
 from subprocess import CalledProcessError, CompletedProcess
-from unittest.mock import patch
+from unittest.mock import Mock, call, patch
 
 from agent.builder import ImageBuilder
 
 
 class TestImageBuilder(unittest.TestCase):
-    def get_builder(self, no_push=False, maximum_compression=True):
+    def get_builder(self, no_push=False, maximum_compression=True, build_runtime_image=False):
         compression = {
             "image_compression": "zstd",
             "image_compression_level": 22,
@@ -29,6 +29,7 @@ class TestImageBuilder(unittest.TestCase):
                     "password": "password",
                 },
                 platform="linux/amd64",
+                build_runtime_image=build_runtime_image,
                 **(compression if maximum_compression else {}),
             )
 
@@ -59,6 +60,45 @@ class TestImageBuilder(unittest.TestCase):
         self.assertNotIn("--output", command)
         self.assertNotIn("push=true", command)
 
+    def test_runtime_build_uses_runtime_target_and_tag(self):
+        command = self.get_builder(build_runtime_image=True)._get_build_command(runtime=True)
+
+        self.assertIn("--target runtime", command)
+        self.assertIn("-t registry.example.com/fodista/bench:candidate-runtime", command)
+        self.assertIn("name=registry.example.com/fodista/bench:candidate-runtime", command)
+        self.assertIn(".runtime.metadata.json", command)
+
+    @patch.object(ImageBuilder, "_push_docker_image")
+    @patch.object(ImageBuilder, "_build_image")
+    def test_runtime_image_is_built_after_full_image(self, build_image, _push_image):
+        builder = self.get_builder(build_runtime_image=True)
+        builder.data = {}
+
+        builder._build_and_push()
+
+        self.assertEqual(build_image.call_args_list, [call(), call(runtime=True)])
+
+    @patch.object(ImageBuilder, "_push_docker_image")
+    @patch.object(ImageBuilder, "_build_image")
+    def test_runtime_image_is_not_built_by_default(self, build_image, _push_image):
+        builder = self.get_builder()
+        builder.data = {}
+
+        builder._build_and_push()
+
+        build_image.assert_called_once_with()
+
+    @patch.object(ImageBuilder, "_push_docker_image")
+    @patch.object(ImageBuilder, "_build_image")
+    def test_no_push_does_not_build_runtime_image(self, build_image, push_image):
+        builder = self.get_builder(no_push=True, build_runtime_image=True)
+        builder.data = {}
+
+        builder._build_and_push()
+
+        build_image.assert_called_once_with()
+        push_image.assert_not_called()
+
     @patch("agent.builder.subprocess.run")
     def test_pushed_digest_is_verified(self, run):
         builder = self.get_builder()
@@ -72,6 +112,42 @@ class TestImageBuilder(unittest.TestCase):
             run.call_args.args[0],
         )
         self.assertEqual(run.call_args.kwargs["timeout"], 5 * 60)
+
+    @patch("agent.builder.subprocess.run")
+    def test_runtime_digest_is_verified_against_runtime_tag(self, run):
+        builder = self.get_builder(build_runtime_image=True)
+        builder.runtime_image_digest = "sha256:def456"
+        builder.docker_config_directory = "/tmp/docker-config"
+
+        builder._verify_pushed_image(runtime=True)
+
+        self.assertIn(
+            "registry.example.com/fodista/bench:candidate-runtime@sha256:def456",
+            run.call_args.args[0],
+        )
+
+    @patch("agent.builder.is_registry_healthy", return_value=True)
+    @patch.object(ImageBuilder, "_verify_pushed_image")
+    def test_full_and_runtime_digests_are_verified_after_push(self, verify, _registry):
+        builder = self.get_builder(build_runtime_image=True)
+        builder.data = {}
+        builder.image_digest = "sha256:abc123"
+        builder.runtime_image_digest = "sha256:def456"
+        builder.job = Mock()
+        builder.job.model.id = 1
+        builder.step = Mock()
+        builder.publish_data = Mock()
+
+        output = builder._push_docker_image()
+
+        self.assertEqual(verify.call_args_list, [call(), call(runtime=True)])
+        self.assertEqual(
+            [item["id"] for item in output],
+            [
+                "registry.example.com/fodista/bench:candidate",
+                "registry.example.com/fodista/bench:candidate-runtime",
+            ],
+        )
 
     def test_push_fails_without_digest(self):
         builder = self.get_builder()
@@ -90,6 +166,15 @@ class TestImageBuilder(unittest.TestCase):
         builder.output["build"] = ['ERROR: process "/bin/sh -c false" did not complete successfully\n']
 
         self.assertFalse(builder._is_retryable_registry_failure())
+
+    def test_runtime_retry_ignores_previous_full_image_output(self):
+        builder = self.get_builder()
+        builder.output["build"] = [
+            "failed to push: connection reset by peer\n",
+            'ERROR: process "/bin/sh -c false" did not complete successfully\n',
+        ]
+
+        self.assertFalse(builder._is_retryable_registry_failure(output_start=1))
 
     @patch.object(ImageBuilder, "_build_image")
     def test_failed_build_cannot_complete_successfully(self, build_image):

--- a/agent/web.py
+++ b/agent/web.py
@@ -214,6 +214,7 @@ def build_image():
         image_compression_level=data.get("image_compression_level", 0),
         force_compression=data.get("force_compression", False),
         oci_mediatypes=data.get("oci_mediatypes", False),
+        build_runtime_image=data.get("build_runtime_image", False),
     )
     job = image_builder.run_remote_builder()
     return {"job": job}

--- a/agent/web.py
+++ b/agent/web.py
@@ -210,6 +210,10 @@ def build_image():
         no_push=data.get("no_push"),
         registry=data.get("registry"),
         platform=data.get("platform", "linux/amd64"),
+        image_compression=data.get("image_compression", "gzip"),
+        image_compression_level=data.get("image_compression_level", 0),
+        force_compression=data.get("force_compression", False),
+        oci_mediatypes=data.get("oci_mediatypes", False),
     )
     job = image_builder.run_remote_builder()
     return {"job": job}


### PR DESCRIPTION
## Summary
- use a persistent docker-container Buildx builder and create/bootstrap it automatically when missing
- support OCI Zstd level 22, forced recompression, and OCI media types while preserving legacy defaults
- publish the canonical full image first and an optional `-runtime` target second
- capture, return, and independently verify both registry digests
- retry transient registry login/push failures and fail the Agent job after exhausted retries
- isolate registry credentials in a temporary Docker config and clean both metadata files

## Verification
- focused Agent suite passed: **18/18**
- Ruff check and format check passed
- Python compilation and `git diff --check` passed
- real local registry push, manifest inspection, digest pull, and container startup passed for Zstd and gzip
- the production-derived runtime measured **635,419,013 bytes**, 74.43% below the current image

## Deployment
Deploy Agent before Press begins sending the new compression and runtime-target parameters. Older callers remain compatible because every new parameter defaults to the existing behavior.

## Compatibility
OCI Zstd layers require Docker Engine 23 or newer on consuming instances.

## Pre-PR Review
No critical or important findings remain. Dual target ordering, output isolation, digest verification, retry handling, credential cleanup, and default compatibility were reviewed.

## Jira
[FA-2363](https://fodista.atlassian.net/browse/FA-2363)
