### PR TITLE
fix(builder): Authenticate Docker Hub for Buildx

### DIFF
--- a/agent/builder.py
+++ b/agent/builder.py
@@ -282,10 +282,13 @@ class ImageBuilder(Base):
         return environment
 
     def _login_to_registry(self, environment):
+        registry_url = self.registry["url"]
+        if registry_url == "registry-1.docker.io":
+            registry_url = "docker.io"
         command = [
             "docker",
             "login",
-            self.registry["url"],
+            registry_url,
             "--username",
             self.registry["username"],
             "--password-stdin",

--- a/agent/tests/test_builder.py
+++ b/agent/tests/test_builder.py
@@ -210,6 +210,7 @@ class TestImageBuilder(unittest.TestCase):
         command = run.call_args.args[0]
         self.assertIn("--password-stdin", command)
         self.assertNotIn("password", command)
+        self.assertEqual(command[2], "registry.example.com")
         self.assertEqual(run.call_args.kwargs["input"], "password")
         self.assertEqual(environment["DOCKER_CONFIG"], "/tmp/docker-config")
         self.assertEqual(environment["BUILDX_CONFIG"], "/persistent/docker/buildx")
@@ -228,6 +229,16 @@ class TestImageBuilder(unittest.TestCase):
 
         self.assertEqual(run.call_count, 2)
         sleep.assert_called_once_with(builder.REGISTRY_RETRY_DELAY)
+
+    @patch("agent.builder.subprocess.run")
+    def test_docker_hub_login_uses_canonical_server(self, run):
+        builder = self.get_builder()
+        builder.registry["url"] = "registry-1.docker.io"
+        builder.docker_config_directory = "/tmp/docker-config"
+
+        builder._login_to_registry({})
+
+        self.assertEqual(run.call_args.args[0][2], "docker.io")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- authenticate Docker Hub through its canonical login endpoint
- preserve configured endpoints for non-Docker Hub registries
- add regression coverage for Docker Hub and custom registries

## Verification
- `python -m unittest agent.tests.test_builder` (19 passed)
- focused pre-commit checks passed
- real Buildx private-image read-back passed with the generated temporary config

## Pre-PR Review
Reviewed the diff for authorization regressions, secret exposure, custom-registry compatibility, and missing verification. No blocking findings remain.