### PR TITLE
perf(builder): Reuse runtime registry cache

### DIFF
--- a/agent/builder.py
+++ b/agent/builder.py
@@ -208,10 +208,22 @@ class ImageBuilder(Base):
         if self.no_cache:
             command = f"{command} --no-cache"
 
+        if runtime and not self.no_push:
+            cache_ref = f"{self.image_repository}:runtime-buildcache"
+            command = f"{command} --cache-from type=registry,ref={cache_ref}"
+            command = (
+                f"{command} --cache-to type=registry,ref={cache_ref},mode=min,"
+                f"compression={self.image_compression},"
+                f"compression-level={self.image_compression_level},"
+                "force-compression=false,oci-mediatypes=true,"
+                "image-manifest=true,ignore-error=true"
+            )
+
         if self.no_push:
             command = f"{command} --load"
         else:
             command = f"{command} --provenance=false"
+            force_compression = self.force_compression and not runtime
             output = ",".join(
                 [
                     "type=image",
@@ -219,7 +231,7 @@ class ImageBuilder(Base):
                     "push=true",
                     f"compression={self.image_compression}",
                     f"compression-level={self.image_compression_level}",
-                    f"force-compression={str(self.force_compression).lower()}",
+                    f"force-compression={str(force_compression).lower()}",
                     f"oci-mediatypes={str(self.oci_mediatypes).lower()}",
                     "name-canonical=true",
                 ]

--- a/agent/tests/test_builder.py
+++ b/agent/tests/test_builder.py
@@ -108,6 +108,26 @@ class TestImageBuilder(unittest.TestCase):
         self.assertIn("name=registry.example.com/fodista/bench:candidate-runtime", command)
         self.assertIn(".runtime.metadata.json", command)
 
+    def test_runtime_build_reuses_registry_cache(self):
+        command = self.get_builder(build_runtime_image=True)._get_build_command(runtime=True)
+
+        cache_ref = "registry.example.com/fodista/bench:runtime-buildcache"
+        self.assertIn(f"--cache-from type=registry,ref={cache_ref}", command)
+        self.assertIn(f"--cache-to type=registry,ref={cache_ref},mode=min", command)
+        self.assertIn("compression=zstd", command)
+        self.assertIn("compression-level=22", command)
+        self.assertIn("force-compression=false", command)
+        self.assertNotIn("force-compression=true", command)
+        self.assertIn("image-manifest=true", command)
+        self.assertIn("ignore-error=true", command)
+
+    def test_full_and_local_builds_do_not_publish_runtime_cache(self):
+        self.assertNotIn("runtime-buildcache", self.get_builder()._get_build_command())
+        self.assertNotIn(
+            "runtime-buildcache",
+            self.get_builder(no_push=True)._get_build_command(runtime=True),
+        )
+
     @patch.object(ImageBuilder, "_push_docker_image")
     @patch.object(ImageBuilder, "_build_image")
     def test_runtime_image_is_built_after_full_image(self, build_image, _push_image):


### PR DESCRIPTION
## Summary
- import and export a release-group runtime cache through the registry
- cache final runtime layers in `mode=min` using Zstandard level 22
- preserve cached runtime compression while retaining forced maximum compression for the full image
- keep cache export non-blocking and skip registry cache for local/no-push builds

## Verification
- focused Agent builder tests: 24 passed
- Ruff, formatting, compile, and diff checks passed
- exact Buildx flags passed a two-build temporary-registry integration test
- second build imported the cache and reused the unchanged compressed layer digest
- no user-facing strings changed; no translation update required

## Deployment order
Deploy this Agent change before the dependent Press runtime-layer PR.

## Pre-PR Review
Reviewed cache scope, tag isolation, registry authentication, first-build cache miss behavior, retry safety, no-push compatibility, compression preservation, and concurrent build correctness. No critical or important findings remain.