### PR TITLE
feat(site): Install destination apps before migrate

### DIFF
--- a/agent/server.py
+++ b/agent/server.py
@@ -323,6 +323,7 @@ class Server(Base):
         skip_backups,
         before_migrate_scripts: dict[str, str] | None = None,
         skip_search_index: bool = True,
+        install_all_apps: bool = False,
     ):
         if before_migrate_scripts is None:
             before_migrate_scripts = {}
@@ -345,6 +346,9 @@ class Server(Base):
         self.reload_nginx()
 
         site = Site(name, target)
+
+        if install_all_apps:
+            site.install_apps(target.apps)
 
         if before_migrate_scripts:
             site.run_app_scripts(before_migrate_scripts)

--- a/agent/tests/test_server.py
+++ b/agent/tests/test_server.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import unittest
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 from agent.server import Server
 
@@ -89,6 +89,41 @@ class TestServerProxyDetection(unittest.TestCase):
         args, _ = render_template.call_args
         _, context, _ = args
         self.assertFalse(context.get("is_proxy_server", False))
+
+    def test_update_site_installs_destination_apps_before_migrate(self):
+        server = self._get_server({})
+        server.move_site = MagicMock()
+        server.reload_nginx = MagicMock()
+        source = MagicMock()
+        target = MagicMock()
+        target.apps = {"frappe": MagicMock(), "erpnext": MagicMock()}
+        source_site = MagicMock()
+        destination_site = MagicMock()
+
+        with patch("agent.server.Bench", side_effect=[source, target]), patch(
+            "agent.server.Site", side_effect=[source_site, destination_site]
+        ):
+            Server.update_site_migrate_job.__wrapped__(
+                server,
+                "example.com",
+                "source",
+                "target",
+                False,
+                False,
+                True,
+                install_all_apps=True,
+            )
+
+        destination_site.install_apps.assert_called_once_with(target.apps)
+        self.assertLess(
+            destination_site.mock_calls.index(call.install_apps(target.apps)),
+            destination_site.mock_calls.index(
+                call.migrate(
+                    skip_search_index=True,
+                    skip_failing_patches=False,
+                )
+            ),
+        )
 
 
 if __name__ == "__main__":

--- a/agent/web.py
+++ b/agent/web.py
@@ -840,6 +840,7 @@ def update_site_migrate(bench, site):
         data.get("skip_backups", False),
         data.get("before_migrate_scripts", {}),
         data.get("skip_search_index", True),
+        data.get("install_all_apps", False),
     )
     return {"job": job}
 


### PR DESCRIPTION
## Summary
- accept the install-all-apps flag for migrate updates
- install every destination bench app before scripts and bench migrate
- preserve the existing flow when the flag is disabled

## Verification
- focused Agent ordering unit test passed on Python 3.10
- ruff, formatting, compile, and diff checks passed

## Pre-PR Review
Reviewed the diff for ordering regressions, backward compatibility, and scope drift. No blocking findings.

Jira: FA-2386