### PR TITLE
fix(callbacks): Bound Press request timeout

### DIFF
--- a/agent/callbacks.py
+++ b/agent/callbacks.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2026, Fodista and contributors
+
 import requests
 
 
@@ -5,4 +7,8 @@ def callback(job, connection, result, *args, **kwargs):
     from agent.server import Server
 
     press_url = Server().press_url
-    requests.post(url=f"{press_url}/api/method/press.api.callbacks.callback", data={"job_id": job.id})
+    requests.post(
+        url=f"{press_url}/api/method/press.api.callbacks.callback",
+        data={"job_id": job.id},
+        timeout=10,
+    )

--- a/agent/tests/test_callbacks.py
+++ b/agent/tests/test_callbacks.py
@@ -1,0 +1,22 @@
+# Copyright (c) 2026, Fodista and contributors
+
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+from agent.callbacks import callback
+
+
+class TestCallbacks(TestCase):
+    def test_callback_has_http_timeout(self):
+        job = MagicMock(id="123")
+
+        with patch("agent.server.Server") as server, patch("agent.callbacks.requests.post") as post:
+            server.return_value.press_url = "https://press.example.com"
+
+            callback(job, None, None)
+
+        post.assert_called_once_with(
+            url="https://press.example.com/api/method/press.api.callbacks.callback",
+            data={"job_id": "123"},
+            timeout=10,
+        )


### PR DESCRIPTION
## Summary

- bound Agent callback requests to Press to 10 seconds
- prevent a stalled TLS handshake from consuming RQ callback death penalties repeatedly
- cover the callback timeout contract with a focused test

## Verification

- `python -m unittest -v agent.tests.test_callbacks`
- `ruff check agent/callbacks.py agent/tests/test_callbacks.py`
- `ruff format --check agent/callbacks.py agent/tests/test_callbacks.py`
- compileall and `git diff --check`

## Translation

No user-facing text changed.

## Pre-PR Review

No task-owned correctness, regression, security, or scope findings.

Jira: FA-2386